### PR TITLE
Add missing requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,9 @@ import setuptools
 with open('README.md', 'r') as f:
     long_description = f.read()
 
+with open('requirements.txt', 'r') as f:
+    install_requires = f.read().splitlines()
+
 setuptools.setup(
     name="aiolmdb",
     version="0.1.1",
@@ -13,6 +16,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/james7132/aiolmdb",
     packages=setuptools.find_packages(),
+    install_requires=install_requires,
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",


### PR DESCRIPTION
When running `pip install aiolmdb`, the `lmdb` library is not automatically downloaded as a dependency.

This pull request should fix the issue.